### PR TITLE
fix(player): Fallback the provider response by returning "undefined"

### DIFF
--- a/src/Services/Player/Song.ts
+++ b/src/Services/Player/Song.ts
@@ -395,6 +395,10 @@ class Song implements Giveable {
 					return undefined
 				}
 			)
+			.catch((e) => {
+				console.warn(e)
+				return undefined
+			})
 		)
 	}
 	
@@ -421,6 +425,10 @@ class Song implements Giveable {
 					}
 				}
 			)
+			.catch((e) => {
+				console.warn(e)
+				return undefined
+			})
 		)
 	}
 


### PR DESCRIPTION
The fallback logic is only triggered when we receive an "undefined" response. However, currently, we do not handle the error, causing it to propagate to the highest level of this extension and resulting in panic for this extension instead of running the fallback logic mentioned above.

To address this issue, this pull request adds error handling with "catch" in all GetLyricsFrom functions. We log the error using "console.warn" to let others see the exception in DevTools, and return "undefined" to correctly execute the fallback logic.

This work is based on #262, but with improved consideration for fallback.

Fixed #253
Fixed #260
