### PR TITLE
Fixed the SongPlaceholder Image not being able to load on Local (or undefined/missing) Songs.

### DIFF
--- a/Source/LyricViews/Shared.ts
+++ b/Source/LyricViews/Shared.ts
@@ -118,6 +118,10 @@ const GenerateBlurredCoverArt = async () => {
 
 	const image = new Image()
 	image.src = coverArt
+	// Added a check to see if the cover art is external. This fixed the SongPlaceholder Image not being able to load.
+	if (coverArt.includes("https://") || coverArt.includes("http://")) {
+        image.crossOrigin = "anonymous";
+    }
 	await image.decode()
 
 	const originalSize = Math.min(image.width, image.height) // Crop to a square


### PR DESCRIPTION
When the currently playing song was Local (or ```undefined```), it just rendered a background without any image.
![image](https://github.com/user-attachments/assets/c202e3da-1b36-4b0e-8120-d6525550c398)
This PR fixes the problem, by setting ```crossOrigin``` to ```anonymous``` for external images in the BG.