### PR TITLE
Keep wrapped lyrics visible and scrollable through the final line

### DIFF
--- a/Extension/Source/Modules/LyricsRenderer/LyricsScroller.ts
+++ b/Extension/Source/Modules/LyricsRenderer/LyricsScroller.ts
@@ -92,6 +92,9 @@ export class LyricsScroller<V extends (BaseVocals | SyncedVocals)> implements Gi
 			)
 		)
 		resizeObserver.observe(this.ScrollContainer)
+		for (const vocalGroup of this.VocalGroups) {
+			resizeObserver.observe(vocalGroup.GroupContainer)
+		}
 
 		// Immediately update our heights
 		this.UpdateLyricHeights()
@@ -175,7 +178,11 @@ export class LyricsScroller<V extends (BaseVocals | SyncedVocals)> implements Gi
 		}
 
 		// Update our container height
-		this.LyricsContainer.style.height = `${totalHeight}px`
+		// Keep enough real scrollable space after the final lyric so it can be
+		// brought above the player controls. Using an explicit calculated height
+		// is important here because SimpleBar does not reliably include a flex
+		// child's trailing margin/padding in its scroll extent.
+		this.LyricsContainer.style.height = `calc(${totalHeight}px + var(--lyrics-scroll-tail, 70cqh))`
 		this.Scroller.recalculate()
 	}
 

--- a/Extension/Source/Stylings/Lyrics.scss
+++ b/Extension/Source/Stylings/Lyrics.scss
@@ -35,9 +35,10 @@
 	flex-direction: column;
 
 	width: 100cqw;
-	height: 0;
+	height: max-content;
+	min-height: 100%;
 
-	container-type: size;
+	container-type: inline-size;
 
 	--vocal-idle-opacity: 0.51;
 	--vocal-active-opacity: 1;
@@ -49,9 +50,12 @@
 	--vocal-lyrics-scale: 7;
 	--maximum-lyrics-size: 3.5rem;
 	--minimum-lyrics-size: 1.85rem;
+	--lyrics-scroll-tail: 70cqh;
 
 	will-change: transform;
-	contain: layout paint;
+	contain: none;
+	box-sizing: border-box;
+	padding-bottom: 0;
 }
 
 /* Group */
@@ -77,7 +81,11 @@
 	margin-bottom: 1cqw;
 
 	will-change: transform;
-	contain: layout paint;
+	contain: layout;
+	width: 100%;
+	max-width: 100%;
+	box-sizing: border-box;
+	overflow: visible;
 }
 
 .VocalsGroup:is(button) {
@@ -161,11 +169,13 @@
 			var(--maximum-lyrics-size));
 
 	will-change: transform, opacity;
-	contain: layout paint;
+	contain: layout;
+	max-width: 100%;
+	overflow: visible;
 }
 
 .Lyrics .Vocals {
-	width: 95cqw;
+	width: 100%;
 }
 
 .Lyrics:has(.AlignedOpposite) .Vocals {
@@ -309,6 +319,8 @@
 	/* Make it so text can wrap and we expand to its size */
 	display: flex;
 	white-space: pre-wrap;
+	max-width: 100%;
+	overflow-wrap: anywhere;
 }
 
 .Vocals.Lead .Line {


### PR DESCRIPTION
Long or wrapped lyric lines can be clipped horizontally, and the bottom of the song cannot always be scrolled far enough above the player controls.

This lets lyric groups wrap within the available width, removes paint containment that clips glyphs, and gives the scroller a measured trailing area. Group resize changes now trigger a fresh height calculation.