### PR TITLE
Handle fullscreen routes without navigation state

### DIFF
--- a/Extension/Source/LyricViews/Page/Fullscreen.ts
+++ b/Extension/Source/LyricViews/Page/Fullscreen.ts
@@ -1016,7 +1016,9 @@ export default class PageView implements Giveable {
 						const notFullscreen = (document.fullscreenElement === null)
 						if (shouldBeFullscreen === notFullscreen) {
 							if (shouldBeFullscreen) {
-								delete SpotifyHistory.location.state.FromPlaybar // Consume this flag (prevents non-user input fullscreen)
+								if (SpotifyHistory.location.state !== undefined) {
+									delete SpotifyHistory.location.state.FromPlaybar // Consume this flag (prevents non-user input fullscreen)
+								}
 								document.documentElement.requestFullscreen()
 							} else {
 								document.exitFullscreen()

--- a/Extension/Source/LyricViews/mod.ts
+++ b/Extension/Source/LyricViews/mod.ts
@@ -268,7 +268,7 @@ OnSpotifyReady
 				ActivePageView.Closed.Connect(() => SetPlaybarPageIconActiveState(false))
 				ActivePageView.Closed.Connect(() => ActivePageView = undefined)
 			} else if (location.pathname === "/BeautifulLyrics/Fullscreen") {
-				ActivePageView = ViewMaid.Give(new FullscreenPageView(location.state.FromPlaybar), "PageView")
+				ActivePageView = ViewMaid.Give(new FullscreenPageView(location.state?.FromPlaybar), "PageView")
 				ActivePageView.Closed.Connect(() => ActivePageView = undefined)
 			}
 		}


### PR DESCRIPTION
Opening the fullscreen route directly can leave the history state undefined. The current code reads and deletes FromPlaybar unconditionally, which throws before the view finishes setting up.

This guards both accesses while preserving the existing FromPlaybar behavior when the flag is present.