### PR TITLE
Fall back cleanly when font and romanization assets are unavailable

### DIFF
--- a/Extension/Source/LyricViews/Page/style.scss
+++ b/Extension/Source/LyricViews/Page/style.scss
@@ -198,7 +198,7 @@ body:has(.BeautifulLyricsPage.Fullscreen) {
 			position: absolute;
 			left: var(--PlayPanelAppliedLeftSpace);
 
-			font-family: "BeautifulLyrics" !important;
+			font-family: var(--encore-body-font-stack, CircularSp, sans-serif) !important;
 
 			container-type: size;
 			z-index: 2;

--- a/Extension/Source/UpdatePopup/style.scss
+++ b/Extension/Source/UpdatePopup/style.scss
@@ -53,7 +53,7 @@
 			width: 100cqw;
 
 			color: white;
-			font-family: "BeautifulLyrics";
+			font-family: var(--encore-body-font-stack, CircularSp, sans-serif);
 			font-size: 11cqh;
 			font-weight: bold;
 			text-align: center;
@@ -67,7 +67,7 @@
 			width: 100cqw;
 
 			color: white;
-			font-family: "BeautifulLyrics";
+			font-family: var(--encore-body-font-stack, CircularSp, sans-serif);
 			font-size: 5cqh;
 			font-weight: bold;
 			text-align: center;
@@ -84,7 +84,7 @@
 			width: 100cqw;
 
 			color: white;
-			font-family: "BeautifulLyrics";
+			font-family: var(--encore-body-font-stack, CircularSp, sans-serif);
 			font-size: 5cqh;
 			font-weight: normal;
 			text-align: center;

--- a/Extension/Source/main.ts
+++ b/Extension/Source/main.ts
@@ -30,50 +30,6 @@ import { CreateElement } from "./LyricViews/Shared.ts"
 import OpenUpdatePopup from "./UpdatePopup/mod.ts"
 
 const Load = async () => {
-	{
-		const fontPromises: Promise<FontFaceSet>[] = []
-		const fonts = [
-			new FontFace(
-				"BeautifulLyrics",
-				"url(https://fonts.socalifornian.live/LyricsRegular.woff2)",
-				{
-					weight: "400",
-					style: "normal"
-				}
-			),
-			new FontFace(
-				"BeautifulLyrics",
-				"url(https://fonts.socalifornian.live/LyricsMedium.woff2)",
-				{
-					weight: "500",
-					style: "normal"
-				}
-			),
-			new FontFace(
-				"BeautifulLyrics",
-				"url(https://fonts.socalifornian.live/LyricsSemibold.woff2)",
-				{
-					weight: "600",
-					style: "normal"
-				}
-			),
-			new FontFace(
-				"BeautifulLyrics",
-				"url(https://fonts.socalifornian.live/LyricsBold.woff2)",
-				{
-					weight: "700",
-					style: "normal"
-				}
-			)
-		]
-		for (const font of fonts) {
-			fontPromises.push(
-				font.load().then(font => document.fonts.add(font))
-			)
-		}
-		await Promise.all(fontPromises)
-	}
-
 	await OnSpotifyReady
 
 	// Custom text rendering, still expirementing so not final yet

--- a/Extension/Spices/Spicetify/Services/Player/LyricUtilities.ts
+++ b/Extension/Spices/Spicetify/Services/Player/LyricUtilities.ts
@@ -46,6 +46,11 @@ const RightToLeftLanguages = [
 
 const RomajiConverter = new Kuroshiro()
 const RomajiPromise = RomajiConverter.init(KuromojiAnalyzer)
+	.then(() => true)
+	.catch(error => {
+		console.warn("Beautiful Lyrics: Japanese romanization unavailable", error)
+		return false
+	})
 
 const KoreanTextTest = /[\uac00-\ud7af]|[\u1100-\u11ff]|[\u3130-\u318f]|[\ua960-\ua97f]|[\ud7b0-\ud7ff]/
 const ChineseTextText = /([\u4E00-\u9FFF])/
@@ -84,16 +89,17 @@ const GenerateJapaneseRomanization = <L extends TextMetadata>(
 	if ((primaryLanguage === "jpn") || JapaneseTextText.test(lyricMetadata.Text)) {
 		return (
 			RomajiPromise.then(
-				() => RomajiConverter.convert(
+				ready => ready ? RomajiConverter.convert(
 					lyricMetadata.Text,
 					{
 						to: "romaji",
 						mode: "spaced"
 					}
-				)
+				) : undefined
 			)
 			.then(
 				result => {
+					if (result === undefined) return
 					lyricMetadata.RomanizedText = result
 					return "Japanese"
 				}


### PR DESCRIPTION
The custom font and Kuromoji assets currently depend on hosts that may be unavailable. When that happens, the extension either falls back to a serif font or stops lyric processing altogether.

This uses Spotify's own font stack and treats Japanese romanization as optional. Lyrics still render when the analyzer cannot initialize.