### PR TITLE
Add optional inline lyric translations

### DIFF
--- a/Extension/Source/LyricViews/Page/Contained.ts
+++ b/Extension/Source/LyricViews/Page/Contained.ts
@@ -13,7 +13,7 @@ import {
 import { Song, SongChanged } from "@Spices/Spicetify/Services/Player/mod.ts"
 
 // Our Modules
-import { CreateLyricsRenderer, SetupRomanizationButton } from "./Shared.ts"
+import { CreateLyricsRenderer, SetupRomanizationButton, SetupTranslationButton } from "./Shared.ts"
 import { CreateElement, ApplyDynamicBackground } from "../Shared.ts"
 
 // Templates
@@ -25,6 +25,7 @@ const Container = `
 const Header = `
 	<div class="ViewControls">
 		<button id="Romanize" class="ViewControl"></button>
+		<button id="Translate" class="ViewControl"></button>
 		<button id="Cinema" class="ViewControl">
 			<svg role="img" height="16" width="16" aria-hidden="true" viewBox="0 0 16 16" data-encore-id="icon" class="Svg-sc-ytk21e-0 Svg-img-16-icon">
 				<path d="M14.55 1c.8 0 1.45.65 1.45 1.45V7h-1.5V2.5h-13v11h5.507V15H1.45C.65 15 0 14.35 0 13.55V2.45C0 1.65.65 1 1.45 1h13.1z"></path><path d="M16 9.757a.75.75 0 0 0-.75-.75H9.068L6.56 6.5h1.385a.75.75 0 1 0 0-1.5H4v3.946a.75.75 0 0 0 1.5 0V7.561l3.076 3.075v3.614c0 .414.336.75.75.75h5.925a.75.75 0 0 0 .75-.75V9.757z"></path>
@@ -77,6 +78,7 @@ export default class PageView implements Giveable {
 			// Grab our controls
 			const changeButton = header.querySelector<HTMLButtonElement>("#Cinema")!
 			const romanizeButton = header.querySelector<HTMLButtonElement>("#Romanize")!
+			const translateButton = header.querySelector<HTMLButtonElement>("#Translate")!
 			const closeButton = header.querySelector<HTMLButtonElement>("#Close")!
 
 			// Handle our close button
@@ -115,6 +117,7 @@ export default class PageView implements Giveable {
 
 			// Setup our romanization button
 			SetupRomanizationButton(romanizeButton, UpdateLyricsRenderer, this.Maid)
+			SetupTranslationButton(translateButton, container, this.Maid)
 		}
 
 		// Now parent our container/header

--- a/Extension/Source/LyricViews/Page/Fullscreen.ts
+++ b/Extension/Source/LyricViews/Page/Fullscreen.ts
@@ -46,7 +46,7 @@ import Slider from "../../Components/Slider.ts"
 import Button from "../../Components/Button.ts"
 
 // Our Modules
-import { CreateLyricsRenderer, SetupRomanizationButton } from "./Shared.ts"
+import { CreateLyricsRenderer, SetupRomanizationButton, SetupTranslationButton } from "./Shared.ts"
 import { CreateElement, GetCoverArtForSong, ApplyDynamicBackground } from "../Shared.ts"
 import LyricViewIcons from "../Icons.ts"
 import Icons from "./Icons.ts"
@@ -111,6 +111,7 @@ const Container = `
 					<div class="ViewControls">
 						<button id="AddToPlaylist" class="ViewControl">${Icons.AddToPlaylist}</button>
 						<button id="Romanize" class="ViewControl"></button>
+						<button id="Translate" class="ViewControl"></button>
 						<button id="SmallerView" class="ViewControl"></button>
 						<button id="Fullscreen" class="ViewControl">${LyricViewIcons.FullscreenOpen}</button>
 						<button id="Close" class="ViewControl">${Icons.CloseView}</button>
@@ -944,6 +945,7 @@ export default class PageView implements Giveable {
 				// Grab our controls
 				const addToPlaylistButton = viewControls.querySelector<HTMLButtonElement>("#AddToPlaylist")!
 				const romanizeButton = viewControls.querySelector<HTMLButtonElement>("#Romanize")!
+				const translateButton = viewControls.querySelector<HTMLButtonElement>("#Translate")!
 				const fullscreenButton = viewControls.querySelector<HTMLButtonElement>("#Fullscreen")!
 				const smallViewButton = viewControls.querySelector<HTMLButtonElement>("#SmallerView")!
 				const closeButton = viewControls.querySelector<HTMLButtonElement>("#Close")!
@@ -1143,6 +1145,7 @@ export default class PageView implements Giveable {
 
 				// Setup our romanization button
 				SetupRomanizationButton(romanizeButton, UpdateLyricsRenderer, this.Maid)
+				SetupTranslationButton(translateButton, container, this.Maid)
 			}
 
 			// Handle our like state

--- a/Extension/Source/LyricViews/Page/Shared.ts
+++ b/Extension/Source/LyricViews/Page/Shared.ts
@@ -18,6 +18,106 @@ import {
 	ToggleLanguageRomanization, IsLanguageRomanized, LanguageRomanizationChanged
 } from "../Shared.ts"
 
+const TranslationStorageKey = "BeautifulLyrics:ShowTranslations"
+const TranslationIcon = `<svg class="BeautifulLyricsTranslationIcon" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12.9 15.1 10.8 13l.1-.1a14.7 14.7 0 0 0 3.1-5.5h2.4V5.8h-5.6V4H9.2v1.8H3.6v1.6h8.8a12.7 12.7 0 0 1-2.7 4.5A12.4 12.4 0 0 1 7.8 9H6.2a14 14 0 0 0 2.4 4L4.4 17.1l1.1 1.1 4.2-4.1 2.6 2.6.6-1.6ZM17.4 10h-1.6l-3.6 10h1.7l.9-2.5h3.7l.9 2.5H21l-3.6-10Zm-2.1 6 1.3-3.8 1.3 3.8h-2.6Z"/></svg>`
+
+const IsTranslationEnabled = () => localStorage.getItem(TranslationStorageKey) === "true"
+const GetTargetLanguage = () => {
+	const locale = Spotify.Locale?.getLocale?.() || navigator.language || "es"
+	return locale.toLowerCase().split(/[-_]/)[0]
+}
+
+const TranslateCurrentLyrics = async (root: HTMLElement) => {
+	if (!IsTranslationEnabled()) return
+	const targetLanguage = GetTargetLanguage()
+	root.querySelectorAll<HTMLElement>(".LyricsTranslation").forEach(translation => {
+		if (translation.dataset.translationTarget !== targetLanguage) translation.remove()
+	})
+	const groups = [...root.querySelectorAll<HTMLElement>(".Lyrics .VocalsGroup")]
+		.filter(group => !group.querySelector(".LyricsTranslation") && group.dataset.translationLoading !== "true")
+
+	for (let start = 0; start < groups.length; start += 8) {
+		await Promise.all(groups.slice(start, start + 8).map(async group => {
+			if (group.querySelector(".LyricsTranslation") || group.dataset.translationLoading === "true") return
+			group.dataset.translationLoading = "true"
+			const sourceClone = group.cloneNode(true) as HTMLElement
+			sourceClone.querySelectorAll(".LyricsTranslation").forEach(node => node.remove())
+			const source = (sourceClone.textContent ?? "").trim()
+			if (!source) {
+				delete group.dataset.translationLoading
+				return
+			}
+			const url = new URL("https://translate.googleapis.com/translate_a/single")
+			url.searchParams.set("client", "gtx")
+			url.searchParams.set("sl", "auto")
+			url.searchParams.set("tl", targetLanguage)
+			url.searchParams.set("dt", "t")
+			url.searchParams.set("q", source)
+			try {
+				const response = await fetch(url)
+				if (!response.ok || !group.isConnected || group.querySelector(".LyricsTranslation")) return
+				const body = await response.json()
+				const detectedLanguage = String(body?.[2] ?? "").toLowerCase().split(/[-_]/)[0]
+				if (detectedLanguage === targetLanguage) return
+				const text = (body?.[0] ?? []).map((part: unknown[]) => part?.[0] ?? "").join("")
+				if (!text) return
+				const translation = document.createElement("span")
+				translation.classList.add("LyricsTranslation")
+				translation.dataset.translationTarget = targetLanguage
+				translation.textContent = text
+				group.appendChild(translation)
+			} catch (error) {
+				console.warn("Beautiful Lyrics: translation failed", error)
+			} finally {
+				delete group.dataset.translationLoading
+			}
+		}))
+	}
+}
+
+export const SetupTranslationButton = (
+	button: HTMLButtonElement,
+	page: HTMLElement,
+	maid: Maid
+) => {
+	button.innerHTML = TranslationIcon
+	const tooltip = Spotify.Tippy(button, { ...Spotify.TippyProps, content: "Translate lyrics" })
+	maid.Give(() => tooltip.destroy())
+
+	const ApplyState = () => {
+		const enabled = IsTranslationEnabled()
+		document.body.classList.toggle("BeautifulLyricsTranslationsEnabled", enabled)
+		button.classList.toggle("Active", enabled)
+		button.setAttribute("aria-pressed", enabled ? "true" : "false")
+		tooltip.setContent(enabled ? "Hide translations" : "Translate lyrics")
+		if (enabled) void TranslateCurrentLyrics(page)
+	}
+
+	button.addEventListener("click", () => {
+		localStorage.setItem(TranslationStorageKey, IsTranslationEnabled() ? "false" : "true")
+		ApplyState()
+	})
+
+	let updateTimer: ReturnType<typeof setTimeout> | undefined
+	const observer = new MutationObserver(records => {
+		if (!IsTranslationEnabled()) return
+		const hasExternalChange = records.some(record =>
+			[...record.addedNodes].some(node =>
+				!(node instanceof HTMLElement && node.classList.contains("LyricsTranslation"))
+			)
+		)
+		if (!hasExternalChange) return
+		clearTimeout(updateTimer)
+		updateTimer = setTimeout(() => void TranslateCurrentLyrics(page), 150)
+	})
+	observer.observe(page, { childList: true, subtree: true })
+	maid.Give(() => {
+		observer.disconnect()
+		clearTimeout(updateTimer)
+	})
+	ApplyState()
+}
+
 // Shared Lyrics Behavior
 export const CreateLyricsRenderer = (
 	container: HTMLDivElement,

--- a/Extension/Source/LyricViews/Page/style.scss
+++ b/Extension/Source/LyricViews/Page/style.scss
@@ -26,6 +26,17 @@ body:has(.BeautifulLyricsPage) {
 		width: auto;
 		aspect-ratio: 1;
 	}
+
+	#Translate svg {
+		height: calc(var(--ViewControlSize) * 0.46);
+		width: auto;
+		aspect-ratio: 1;
+	}
+
+	#Translate.Active {
+		color: var(--spice-button-active, #1ed760);
+		opacity: 1;
+	}
 }
 
 .BeautifulLyricsPage {

--- a/Extension/Source/Modules/LyricsRenderer/LyricsScroller.ts
+++ b/Extension/Source/Modules/LyricsRenderer/LyricsScroller.ts
@@ -92,6 +92,9 @@ export class LyricsScroller<V extends (BaseVocals | SyncedVocals)> implements Gi
 			)
 		)
 		resizeObserver.observe(this.ScrollContainer)
+		for (const vocalGroup of this.VocalGroups) {
+			resizeObserver.observe(vocalGroup.GroupContainer)
+		}
 
 		// Immediately update our heights
 		this.UpdateLyricHeights()

--- a/Extension/Source/Stylings/Lyrics.scss
+++ b/Extension/Source/Stylings/Lyrics.scss
@@ -54,6 +54,21 @@
 	contain: layout paint;
 }
 
+.LyricsTranslation {
+	display: none;
+	margin-top: 0.24em;
+	font-family: "BeautifulLyrics", var(--encore-body-font-stack, CircularSp, sans-serif);
+	font-size: max(0.68em, 16px);
+	font-weight: 600;
+	line-height: 1.3;
+	opacity: 0.84;
+	pointer-events: none;
+}
+
+body.BeautifulLyricsTranslationsEnabled .LyricsTranslation {
+	display: block;
+}
+
 /* Group */
 .VocalsGroup {
 	margin: 0;


### PR DESCRIPTION
Adds a translation control alongside the existing page controls. Translations are shown below each lyric line and use Spotify's current locale as the target language.

The preference is saved across contained and fullscreen views. Lines already written in the target language are left alone, and renderer size changes are observed so translated text remains scrollable.